### PR TITLE
docs: 加升级路径 + 样本回流 Discussions 模板

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,72 @@
+title: "[样本] "
+labels: ["sample"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **贴一份你跑过 qu-ai-wei 的原文 + 终稿**,帮作者看它在真实世界里跑得怎么样 —— 哪些规则命中、哪些漏判、哪些过度修正。
+        后续版本会拿这些样本做 regression。
+
+        不想贴原文全文?只贴你关心的那几句就够了。贴之前**请自行脱敏**(删掉人名、公司名、内部信息)。
+
+  - type: textarea
+    id: original
+    attributes:
+      label: 原文
+      description: 粘贴让 qu-ai-wei 改写的那段文字(或关键段落)
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: qu-ai-wei 给的终稿
+      description: v0.6.0 起连「打磨报告」一起贴最好,能帮作者看上下文
+    validations:
+      required: true
+
+  - type: dropdown
+    id: verdict
+    attributes:
+      label: 你觉得改得怎么样
+      options:
+        - 改得不错 —— 该删的删了,该留的留了
+        - 改得可以 —— 但漏了一些明显的 AI 腔
+        - 改过头了 —— 该留的毛边被删了
+        - 改坏了 —— 改出了原文没有的内容
+        - 其他(底下文字说)
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 具体说说
+      description: 如果上面选了"漏了 / 改过头 / 改坏",指给作者看是哪句哪处
+      placeholder: "例如:倒数第三段的「确诊为 xx」被改成了「被认为是 xx」,这是 2025 鲜活词,本不该改"
+
+  - type: input
+    id: platform
+    attributes:
+      label: 在哪个平台跑的
+      placeholder: "Claude Code / Cursor / Windsurf / Warp / ChatGPT / Kimi / 其他"
+
+  - type: input
+    id: genre
+    attributes:
+      label: 原文的语体(可选)
+      placeholder: "朋友圈 / 公众号 / 产品文案 / 工作邮件 / PRD / 特稿 ..."
+
+  - type: input
+    id: version
+    attributes:
+      label: 跑的是哪个版本(可选)
+      placeholder: "v0.6.0"
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: 使用许可
+      options:
+        - label: "我同意把这份样本用于 qu-ai-wei 的 regression 测试和规则改进。"
+          required: true

--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ cp ~/qu-ai-wei/WARP.md ~/.warp/WARP.md
 
 把 [`SKILL.md`](./SKILL.md) 的正文直接粘到模型的自定义指令或系统提示里，跳过顶部 `---` 包起来的 YAML frontmatter 那段。
 
+## 升级
+
+装好后想拿到最新规则：
+
+```bash
+# Claude Code / OpenCode:一行搞定
+bash ~/.claude/skills/qu-ai-wei/update.sh
+
+# 等价的手工做法
+cd ~/.claude/skills/qu-ai-wei && git pull
+
+# Cursor / Windsurf / Warp:在 clone 出来的那份上 pull,再覆盖回项目
+cd ~/qu-ai-wei && git pull
+cp ~/qu-ai-wei/.cursorrules /path/to/your-project/.cursorrules
+cp ~/qu-ai-wei/WARP.md      /path/to/your-project/WARP.md
+```
+
+`update.sh` 会打印 `旧版本 → 新版本` 和本版发布页链接,没有新版就提示「已是最新」。每版具体变化见 [Releases](https://github.com/hzblacksmith/qu-ai-wei/releases)。
+
 ## 用法
 
 ### 自然语言触发（推荐）

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+cd "$DIR"
+
+before="$(git describe --tags --abbrev=0 2>/dev/null || echo '未知')"
+git pull --ff-only
+after="$(git describe --tags --abbrev=0 2>/dev/null || echo '未知')"
+
+if [ "$before" = "$after" ]; then
+  echo "qu-ai-wei $after — 已是最新"
+else
+  echo "qu-ai-wei: $before → $after"
+  echo "本版变更：https://github.com/hzblacksmith/qu-ai-wei/releases/tag/$after"
+fi


### PR DESCRIPTION
## Summary

- **9 个历史版本 backfill 上了 GitHub Releases**(v0.4.0 → v0.6.0),v0.6.0 标为 Latest。Release body 直接用 README Version History 的内容,不重写
- **新增 `update.sh`**:进装好的 clone 目录 `git pull --ff-only`,打印「旧版本号 → 新版本号」+ Releases 链接,已是最新就提示。版本号用 `git describe --tags --abbrev=0` 取,不引 VERSION 文件
- **README 加「升级」章节**:Claude Code / OpenCode 一行 `update.sh`;Cursor / Windsurf / Warp 在 clone 目录 pull 后再覆盖回项目
- **新增 `.github/DISCUSSION_TEMPLATE/show-and-tell.yml`**:用户主动贴原文 / 终稿 + 四档自评裁决 + 平台 + 语体 + 版本 + 使用许可勾选。对齐 Show and tell 分类,带脱敏提示

## 设计取舍

**为什么 opt-in Discussions 模板,而不是本地遥测 / CLI 日志?**

qu-ai-wei 没有 runtime —— 它是 markdown 提示文件,宿主模型(Claude Code / Cursor / Warp / 其他)读了直接跑,作者这边没有进程可挂钩。要做自动遥测就得另出一个 CLI wrapper,但这会:

1. 碰用户的写作草稿,默认开启的任何数据回传都会破坏信任(这个 skill 本身就是为"让写作更有人味"服务的,讽刺就大了)
2. 拆分发路径(现在一句 `git clone` 搞定)
3. 引入「这个二进制可信吗」的心智负担

所以路径收窄到一条:**用户自己觉得有意思才贴出来,且每次显式勾选使用许可**。维护成本为零,样本质量(带用户裁决、带语体)比任何自动采集都高。

## Test plan

- [x] `bash -n update.sh` 通过
- [x] `yaml.safe_load(.github/DISCUSSION_TEMPLATE/show-and-tell.yml)` 通过
- [ ] (合并后)打开一个 Discussion in Show and tell 看到模板确实加载
- [ ] (合并后)从装好的 clone 目录跑一次 `bash update.sh`,确认「已是最新」路径输出正常

## Release list (backfilled)

- [v0.6.0](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.6.0) (Latest)
- [v0.5.6](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.6) · [v0.5.5](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.5) · [v0.5.4](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.4) · [v0.5.3](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.3) · [v0.5.2](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.2) · [v0.5.1](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.1) · [v0.5.0](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.5.0)
- [v0.4.0](https://github.com/hzblacksmith/qu-ai-wei/releases/tag/v0.4.0)