### PR TITLE
feat: native multi-platform skill installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,51 +61,69 @@ v0.6.0 起,这个 skill 同时扮演两个角色:
 
 ## 安装
 
-### Claude Code
+### 一键安装到 skills 目录（推荐）
 
 ```bash
-# 方法一:git clone(推荐)
-git clone https://github.com/hzblacksmith/qu-ai-wei.git ~/.claude/skills/qu-ai-wei
+git clone https://github.com/hzblacksmith/qu-ai-wei.git ~/qu-ai-wei
+cd ~/qu-ai-wei
 
-# 方法二:手动下载
-# 从 GitHub 下载 zip,解压到 ~/.claude/skills/qu-ai-wei/
+# 按平台安装（可重复执行）
+bash scripts/install-skill.sh --platform codex
+bash scripts/install-skill.sh --platform cursor
+bash scripts/install-skill.sh --platform factory
+bash scripts/install-skill.sh --platform slate
+bash scripts/install-skill.sh --platform kiro
+bash scripts/install-skill.sh --platform hermes
+
+# 一次装全
+bash scripts/install-skill.sh --platform all
 ```
 
-### OpenCode
+默认会安装到 `<skills-root>/qu-ai-wei`（不是固定某个词前缀）。对应平台目录：
 
-OpenCode 也会扫描 `~/.claude/skills/`,所以 Claude Code 的安装会自动被识别。或者单独放在 `~/.config/opencode/skills/qu-ai-wei/`。
+| 平台 | 参数 | 目标目录 |
+|---|---|---|
+| OpenAI Codex CLI | `--platform codex` | `~/.codex/skills/qu-ai-wei` |
+| Cursor | `--platform cursor` | `~/.cursor/skills/qu-ai-wei` |
+| Factory Droid | `--platform factory` | `~/.factory/skills/qu-ai-wei` |
+| Slate | `--platform slate` | `~/.slate/skills/qu-ai-wei` |
+| Kiro | `--platform kiro` | `~/.kiro/skills/qu-ai-wei` |
+| Hermes | `--platform hermes` | `~/.hermes/skills/qu-ai-wei` |
 
-### Cursor / Windsurf
+可选参数：
 
-把 `.cursorrules` 复制到项目根目录：
+- `--name <dir>`：自定义安装目录名（默认 `qu-ai-wei`）
+- `--mode copy`：复制而非软链接（默认 `symlink`）
+- `--to <skills-root>`：安装到任意自定义技能目录（可重复）
+- `--host`：`--platform` 的别名（兼容旧习惯）
+
+例如：
 
 ```bash
-# 先 clone(如已装 Claude Code 可跳过)
-git clone https://github.com/hzblacksmith/qu-ai-wei.git ~/qu-ai-wei
+# 自定义目录名
+bash scripts/install-skill.sh --platform codex --name qu-ai-wei-cn
 
-# 复制到项目根
+# 自定义平台目录
+bash scripts/install-skill.sh --to ~/.my-agent/skills --name qu-ai-wei
+```
+
+### Claude Code / OpenCode（兼容原方式）
+
+也可以直接放在 `~/.claude/skills/qu-ai-wei/`（OpenCode 会扫描这个目录）。
+
+### Cursor / Windsurf / Warp（文件级兼容方式）
+
+如果你的环境更偏好项目级规则文件，继续使用下面方式：
+
+```bash
+# Cursor / Windsurf
 cp ~/qu-ai-wei/.cursorrules /path/to/your-project/.cursorrules
-# Windsurf:同时复制一份为 .windsurfrules
 cp ~/qu-ai-wei/.cursorrules /path/to/your-project/.windsurfrules
-```
 
-之后在 Cursor / Windsurf 里说「帮我去 AI 味」「改得说人话」即可自动触发。
-
-### Warp
-
-把 `WARP.md` 放到项目根目录，或 `~/.warp/WARP.md` 全局生效：
-
-```bash
-# 先 clone(如已装 Claude Code 可跳过)
-git clone https://github.com/hzblacksmith/qu-ai-wei.git ~/qu-ai-wei
-
-# 项目级
+# Warp
 cp ~/qu-ai-wei/WARP.md /path/to/your-project/WARP.md
-# 或全局
 cp ~/qu-ai-wei/WARP.md ~/.warp/WARP.md
 ```
-
-之后在 Warp 里说「帮我去 AI 味」「改得说人话」即可自动触发。
 
 ### 其他支持自定义指令的模型（ChatGPT / DeepSeek / Kimi / 通义 等）
 
@@ -116,16 +134,18 @@ cp ~/qu-ai-wei/WARP.md ~/.warp/WARP.md
 装好后想拿到最新规则：
 
 ```bash
-# Claude Code / OpenCode:一行搞定
-bash ~/.claude/skills/qu-ai-wei/update.sh
-
-# 等价的手工做法
-cd ~/.claude/skills/qu-ai-wei && git pull
-
-# Cursor / Windsurf / Warp:在 clone 出来的那份上 pull,再覆盖回项目
+# 更新 repo（推荐）
 cd ~/qu-ai-wei && git pull
-cp ~/qu-ai-wei/.cursorrules /path/to/your-project/.cursorrules
-cp ~/qu-ai-wei/WARP.md      /path/to/your-project/WARP.md
+
+# 如果你用的是 symlink 模式（默认），到这里就完成了
+# 如果你用的是 copy 模式，重新安装一次覆盖
+bash scripts/install-skill.sh --platform all --mode copy --force
+```
+
+也可以在任一已安装目录直接跑：
+
+```bash
+bash ~/.codex/skills/qu-ai-wei/update.sh
 ```
 
 `update.sh` 会打印 `旧版本 → 新版本` 和本版发布页链接,没有新版就提示「已是最新」。每版具体变化见 [Releases](https://github.com/hzblacksmith/qu-ai-wei/releases)。

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DEFAULT_NAME="qu-ai-wei"
+NAME="$DEFAULT_NAME"
+MODE="symlink"
+FORCE=0
+DRY_RUN=0
+PLATFORM_ARGS=()
+CUSTOM_ROOTS=()
+
+ALL_PLATFORMS=(codex cursor factory slate kiro hermes)
+
+usage() {
+  cat <<'EOF'
+install-skill.sh [options]
+
+Install this skill to platform-native skills directories.
+
+At least one of:
+  --platform <name>    codex | cursor | factory | slate | kiro | hermes | all
+                       Can be repeated or comma-separated.
+  --to <skills-dir>    Custom skills root directory. Can be repeated.
+
+Optional:
+  --name <dir>         Skill directory name under <skills-dir>/ (default: qu-ai-wei)
+  --mode <mode>        symlink | copy (default: symlink)
+  --force              Replace existing target directory/symlink
+  --dry-run            Print planned actions without changing files
+  -h, --help           Show this help
+
+Examples:
+  bash scripts/install-skill.sh --platform codex
+  bash scripts/install-skill.sh --platform cursor --platform slate
+  bash scripts/install-skill.sh --platform codex,cursor,factory --name qu-ai-wei
+  bash scripts/install-skill.sh --platform all --force
+  bash scripts/install-skill.sh --to ~/.my-agent/skills --name qu-ai-wei
+EOF
+}
+
+normalize_platform() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]'
+}
+
+has_item() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [ "$item" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+platform_root() {
+  case "$1" in
+    codex)   printf '%s/.codex/skills' "$HOME" ;;
+    cursor)  printf '%s/.cursor/skills' "$HOME" ;;
+    factory) printf '%s/.factory/skills' "$HOME" ;;
+    slate)   printf '%s/.slate/skills' "$HOME" ;;
+    kiro)    printf '%s/.kiro/skills' "$HOME" ;;
+    hermes)  printf '%s/.hermes/skills' "$HOME" ;;
+    *) return 1 ;;
+  esac
+}
+
+run_cmd() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] %s\n' "$*"
+  else
+    "$@"
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --platform|--host)
+      [ $# -ge 2 ] || { echo "错误: $1 缺少参数" >&2; exit 1; }
+      PLATFORM_ARGS+=("$2")
+      shift 2
+      ;;
+    --to)
+      [ $# -ge 2 ] || { echo "错误: --to 缺少参数" >&2; exit 1; }
+      CUSTOM_ROOTS+=("$2")
+      shift 2
+      ;;
+    --name)
+      [ $# -ge 2 ] || { echo "错误: --name 缺少参数" >&2; exit 1; }
+      NAME="$2"
+      shift 2
+      ;;
+    --mode)
+      [ $# -ge 2 ] || { echo "错误: --mode 缺少参数" >&2; exit 1; }
+      MODE="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "错误:未知参数 $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+[ "${#PLATFORM_ARGS[@]}" -gt 0 ] || [ "${#CUSTOM_ROOTS[@]}" -gt 0 ] || {
+  echo "错误: 请至少指定 --platform 或 --to" >&2
+  usage >&2
+  exit 1
+}
+
+if [ "$MODE" != "symlink" ] && [ "$MODE" != "copy" ]; then
+  echo "错误: --mode 只能是 symlink 或 copy" >&2
+  exit 1
+fi
+
+TARGET_ROOTS=()
+TARGET_LABELS=()
+
+add_target_root() {
+  local root="$1"
+  local label="$2"
+  if [ "${#TARGET_ROOTS[@]}" -eq 0 ]; then
+    TARGET_ROOTS+=("$root")
+    TARGET_LABELS+=("$label")
+    return
+  fi
+  if ! has_item "$root" "${TARGET_ROOTS[@]}"; then
+    TARGET_ROOTS+=("$root")
+    TARGET_LABELS+=("$label")
+  fi
+}
+
+arg=""
+entry=""
+norm=""
+if [ "${#PLATFORM_ARGS[@]}" -gt 0 ]; then
+  for arg in "${PLATFORM_ARGS[@]}"; do
+    IFS=',' read -r -a entries <<< "$arg"
+    for entry in "${entries[@]}"; do
+      norm="$(normalize_platform "$entry")"
+      [ -n "$norm" ] || continue
+      if [ "$norm" = "all" ]; then
+        for entry in "${ALL_PLATFORMS[@]}"; do
+          add_target_root "$(platform_root "$entry")" "$entry"
+        done
+        continue
+      fi
+      if ! platform_root "$norm" >/dev/null 2>&1; then
+        echo "错误: 不支持的平台 '$norm'" >&2
+        echo "支持: codex, cursor, factory, slate, kiro, hermes, all" >&2
+        exit 1
+      fi
+      add_target_root "$(platform_root "$norm")" "$norm"
+    done
+  done
+fi
+
+root=""
+if [ "${#CUSTOM_ROOTS[@]}" -gt 0 ]; then
+  for root in "${CUSTOM_ROOTS[@]}"; do
+    [ -n "$root" ] || continue
+    if [ "${root#~/}" != "$root" ]; then
+      root="$HOME/${root#~/}"
+    fi
+    root="${root%/}"
+    add_target_root "$root" "custom"
+  done
+fi
+
+[ "${#TARGET_ROOTS[@]}" -gt 0 ] || { echo "错误: 没有可安装的目标目录" >&2; exit 1; }
+
+if [ "$MODE" = "copy" ] && ! command -v rsync >/dev/null 2>&1; then
+  echo "错误: copy 模式依赖 rsync，但当前环境没有 rsync" >&2
+  exit 1
+fi
+
+echo "repo:   $REPO_ROOT"
+echo "name:   $NAME"
+echo "mode:   $MODE"
+echo "targets:"
+for root in "${TARGET_ROOTS[@]}"; do
+  echo "  - $root/$NAME"
+done
+echo ""
+
+dest=""
+idx=0
+label=""
+for idx in "${!TARGET_ROOTS[@]}"; do
+  root="${TARGET_ROOTS[$idx]}"
+  label="${TARGET_LABELS[$idx]}"
+  dest="$root/$NAME"
+
+  run_cmd mkdir -p "$root"
+
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    if [ "$FORCE" -ne 1 ]; then
+      echo "错误: 目标已存在: $dest (加 --force 覆盖)" >&2
+      exit 1
+    fi
+    run_cmd rm -rf "$dest"
+  fi
+
+  if [ "$MODE" = "symlink" ]; then
+    run_cmd ln -s "$REPO_ROOT" "$dest"
+  else
+    run_cmd mkdir -p "$dest"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[dry-run] rsync -a --delete --exclude .git/ --exclude .gitignore $REPO_ROOT/ $dest/"
+    else
+      rsync -a --delete --exclude ".git/" --exclude ".gitignore" "$REPO_ROOT/" "$dest/"
+    fi
+  fi
+
+  echo "✔ [$label] -> $dest"
+done
+
+echo ""
+echo "完成。"


### PR DESCRIPTION
## Summary
- add scripts/install-skill.sh for native multi-platform installation
- support --platform for codex/cursor/factory/slate/kiro/hermes and --platform all
- support custom roots via --to and keep --host as compatibility alias
- default install directory name is qu-ai-wei (not platform-specific naming)
- update README install/upgrade docs to use installer as default flow

## Validation
- bash -n scripts/install-skill.sh
- dry-run checks:
  - --platform codex
  - --platform all
  - --to ~/.test-agent/skills --name demo-skill
  - --host cursor
