### PR TITLE
ci: auto-tag and release on version-bump commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+name: Tag and release on version bump
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to tag (back-fill). Required together with tag.'
+        required: false
+      tag:
+        description: 'Tag in vX.Y.Z form (back-fill). Required together with sha.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve tag and target SHA
+        id: resolve
+        env:
+          IN_SHA: ${{ inputs.sha }}
+          IN_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          mode=skip
+          tag=
+          sha=
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${IN_SHA}${IN_TAG}" ]; then
+            if [ -z "$IN_SHA" ] || [ -z "$IN_TAG" ]; then
+              echo "::error::both sha and tag must be supplied together"; exit 1
+            fi
+            if ! [[ "$IN_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::tag must look like vX.Y.Z"; exit 1
+            fi
+            tag="$IN_TAG"
+            sha="$IN_SHA"
+            mode=dispatch
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            t="${GITHUB_REF#refs/tags/}"
+            if [[ "$t" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              tag="$t"
+              sha="$GITHUB_SHA"
+              mode=tag-push
+            else
+              echo "tag $t does not match vX.Y.Z; skipping"
+            fi
+          elif [[ "${GITHUB_REF}" == refs/heads/main ]]; then
+            subject="$(git log -1 --pretty=%s)"
+            if [[ "$subject" =~ ^v([0-9]+\.[0-9]+\.[0-9]+): ]]; then
+              tag="v${BASH_REMATCH[1]}"
+              sha="$GITHUB_SHA"
+              mode=main-push
+            else
+              echo "no vX.Y.Z: prefix on commit subject; skipping"
+            fi
+          fi
+
+          {
+            echo "mode=$mode"
+            echo "tag=$tag"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip if release already exists
+        if: steps.resolve.outputs.mode != 'skip'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.resolve.outputs.tag }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release already exists for ${{ steps.resolve.outputs.tag }}; skipping"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes and title from CHANGELOG.md
+        if: steps.resolve.outputs.mode != 'skip' && steps.existing.outputs.exists == 'false'
+        id: notes
+        run: |
+          set -euo pipefail
+          tag="${{ steps.resolve.outputs.tag }}"
+
+          header="$(awk -v t="$tag" '
+            BEGIN { gsub(/\./, "\\.", t) }
+            $0 ~ "^### "t"([^0-9.]|$)" {
+              sub(/^### /, "")
+              print
+              exit
+            }
+          ' CHANGELOG.md)"
+
+          if [ -z "$header" ]; then
+            echo "::error::no CHANGELOG.md heading found for $tag"; exit 1
+          fi
+
+          awk -v t="$tag" '
+            BEGIN { gsub(/\./, "\\.", t) }
+            $0 ~ "^### "t"([^0-9.]|$)" { in_section=1; next }
+            in_section && /^### v/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            echo "::error::no CHANGELOG.md body found for $tag"; exit 1
+          fi
+
+          if [[ "$header" == *" · "* ]]; then
+            summary="${header#* · }"
+            title="$tag — $summary"
+          else
+            title="$tag"
+          fi
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag (if missing) and release
+        if: steps.resolve.outputs.mode != 'skip' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.resolve.outputs.tag }}"
+          sha="${{ steps.resolve.outputs.sha }}"
+
+          git fetch --tags --force origin 2>/dev/null || true
+          existing_sha="$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null || true)"
+
+          if [ -z "$existing_sha" ]; then
+            git tag "$tag" "$sha"
+            git push origin "refs/tags/$tag"
+          elif [ "$existing_sha" != "$sha" ]; then
+            echo "::error::tag $tag already points to $existing_sha but we want $sha — refusing to move the tag"
+            exit 1
+          fi
+
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$sha" \
+            --title "${{ steps.notes.outputs.title }}" \
+            --notes-file release-notes.md


### PR DESCRIPTION
## Summary

The repo had no release automation — `git log` shows version-bump commits like `v0.7.0:`, `v0.6.6:`, but tags and Releases were created by hand. PR [#23](https://github.com/LifelongLazyLearner/qu-ai-wei/pull/23) bumped the version to v0.7.0 on 2026-05-12 (SHA `b963345`) and was merged, but no `v0.7.0` tag was pushed and no GitHub Release was published. PR #25 then landed on top, so the gap persists.

This adds `.github/workflows/release.yml` to close the gap going forward and to back-fill v0.7.0.

## How it works

Three triggers, one job:

| Trigger | Behavior |
|---|---|
| `push` to `main` with HEAD commit subject matching `^vX.Y.Z:` | Tag that commit, publish a Release whose body is the matching `### vX.Y.Z(...)` block of `CHANGELOG.md`. |
| `push` of a `v*.*.*` tag | Publish a Release at the tagged commit if none exists yet. |
| `workflow_dispatch` with `sha` + `tag` inputs | Idempotent back-fill from the Actions UI. |

Other defenses:
- Already-released? `gh release view` short-circuits → no-op.
- Tag exists at a different SHA than we'd target? Hard-fail (won't silently move a published tag).
- Tag pushes generated by the workflow's own `GITHUB_TOKEN` don't re-trigger workflows, so no loop.
- Release title preserves the past `vX.Y.Z — <summary>` convention by lifting the ` · <summary>` suffix from the CHANGELOG heading. Falls back to bare `vX.Y.Z` when CHANGELOG has no summary suffix (matches v0.6.3 / v0.6.4 history).

## v0.7.0 catch-up (after this merges)

Once this PR is merged, finish the v0.7.0 catch-up by either of these — both are idempotent:

**Option A — push the tag locally:**
```
git fetch origin
git tag v0.7.0 b963345
git push origin v0.7.0
```
The workflow's `push: tags: ['v*.*.*']` trigger picks it up and publishes the Release with title `v0.7.0 — 文档结构重整,无行为改变` and body from `CHANGELOG.md`.

**Option B — Actions UI:** run the workflow with inputs:
- `sha` = `b963345`
- `tag` = `v0.7.0`

## Review gates (per AGENTS.md)

Three adversarial reviewers ran in parallel; final-round verdicts:
- CEO / holistic: **APPROVE**
- 日常中文表达 (adversarial): **APPROVE**
- Engineering: **APPROVE**

CEO Round 1 flagged three items (rich title from CHANGELOG, hard-fail on tag-SHA mismatch, explicit catch-up instructions); all three are addressed in this PR and confirmed in Round 2.

## Test plan

Locally dry-run against the actual `CHANGELOG.md`:

- [x] `awk` body extraction for v0.7.0 → 22 lines, ends cleanly at `### v0.6.6`.
- [x] Title extraction: `v0.7.0` → `v0.7.0 — 文档结构重整,无行为改变`; older versions without ` · summary` → bare `vX.Y.Z`.
- [x] `^### vX.Y.Z([^0-9.]|$)` regex correctly distinguishes `v0.7.0` from `v0.7.10` and from `v0.7` prefix matches.

After merge, verify by either Option A or B above; check the v0.7.0 Release appears on the Releases page with the expected title and body.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154PyqrQL7utedH8PdqHgZ9)_