### PR TITLE
ci: harden release workflow after v0.7.0 dispatch incident

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -65,6 +65,14 @@ jobs:
             else
               echo "no vX.Y.Z: prefix on commit subject; skipping"
             fi
+          fi
+
+          if [ -n "$sha" ]; then
+            full_sha="$(git rev-parse -q --verify "$sha^{commit}" 2>/dev/null || true)"
+            if [ -z "$full_sha" ]; then
+              echo "::error::could not resolve sha $sha to a commit in the checked-out history"; exit 1
+            fi
+            sha="$full_sha"
           fi
 
           {
@@ -147,6 +155,5 @@ jobs:
 
           gh release create "$tag" \
             --repo "$GITHUB_REPOSITORY" \
-            --target "$sha" \
             --title "${{ steps.notes.outputs.title }}" \
             --notes-file release-notes.md


### PR DESCRIPTION
## Background

PR #26 landed the release workflow and you back-filled v0.7.0 via `workflow_dispatch` with `sha=b963345, tag=v0.7.0`. The tag was created at the right commit (`b96334586d48ad0a4698abd2717e22cf8eb4f196`), but the **GitHub Release was not created** — confirmed via `GET /releases/tags/v0.7.0` returning 404.

## Diagnosis

Workflow logs weren't fully captured, but the state (tag present, release absent) points to one of:

1. **`gh release create --target b963345` failed server-side.** `gh` documents `--target` as accepting a *full* commit SHA. The 7-char short SHA you supplied flowed through unchanged.
2. **A retry would also have failed** at the tag-mismatch hard-fail check, because `git rev-parse refs/tags/v0.7.0^{commit}` returns the full SHA `b96334586d48…` while the user-supplied `sha` was still the short `b963345`. The strict-equality comparison rejected the retry.

The Node.js 20 deprecation warning you pasted was noise — a yellow advisory unrelated to the actual failure.

## Fix

Three small changes to `.github/workflows/release.yml`:

| Change | Why |
|---|---|
| Normalize input `sha` to a full commit SHA via `git rev-parse "$sha^{commit}"` right after mode detection. Hard-fail if unresolvable. | Removes the short/full mismatch on retries. Uniform across `dispatch` / `tag-push` / `main-push` paths (no-op for the latter two since `$GITHUB_SHA` is already full). |
| Drop `--target` from `gh release create`. | Once the tag exists, the Releases API anchors at the tag's commit and ignores `target_commitish`. Removing the flag removes the most likely point of failure. |
| `actions/checkout@v4` → `@v5`. | Silences the Node 20 deprecation warning (v5 uses Node 24, otherwise drop-in). |

## After this merges

Re-run the same workflow_dispatch you ran before:
- `sha = b963345`
- `tag = v0.7.0`

Expected path: normalize → full SHA matches existing tag → skip git tag/push → `gh release view` returns 404 → `gh release create` succeeds → release `v0.7.0 — 文档结构重整,无行为改变` appears with body from `CHANGELOG.md`.

## Review gates (per AGENTS.md)

Three adversarial reviewers ran in parallel; all approved:
- CEO / holistic: **APPROVE**
- 日常中文表达 (adversarial): **APPROVE**
- Engineering: **APPROVE**

## Test plan

- [x] `git rev-parse b963345^{commit}` locally returns `b96334586d48ad0a4698abd2717e22cf8eb4f196` (full SHA expansion confirmed).
- [x] CHANGELOG body / title extraction logic unchanged — still produces `v0.7.0 — 文档结构重整,无行为改变`.
- [ ] After merge: workflow_dispatch with `sha=b963345, tag=v0.7.0` completes green and creates the v0.7.0 release.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154PyqrQL7utedH8PdqHgZ9)_