### PR TITLE
[codex] Organize translated READMEs and embed demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Language](https://img.shields.io/badge/lang-简体中文-red.svg)](#)
 [![GitHub stars](https://img.shields.io/github/stars/LifelongLazyLearner/qu-ai-wei?style=social)](https://github.com/LifelongLazyLearner/qu-ai-wei/stargazers)
 
-语言: 简体中文 | [English](./README.en.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md)
+语言: 简体中文 | [English](./readmes/README.en.md) | [日本語](./readmes/README.ja.md) | [한국어](./readmes/README.ko.md) | [Español](./readmes/README.es.md)
 
 > ⚠️ **0.x 开发版（当前 v0.7.0）:** qu-ai-wei 仍在迭代，规则、分类、API 都可能变动。欢迎提 [issue](https://github.com/LifelongLazyLearner/qu-ai-wei/issues) / [discussion](https://github.com/LifelongLazyLearner/qu-ai-wei/discussions) / PR 反馈。
 >

--- a/readmes/README.en.md
+++ b/readmes/README.en.md
@@ -1,10 +1,12 @@
 # qu-ai-wei
 
-[简体中文](./README.md) | English | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md)
+[简体中文](../README.md) | English | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md)
 
 qu-ai-wei is an agent skill for cleaning up AI-sounding writing in **Simplified Chinese**. It helps turn a Simplified Chinese draft from "obviously AI-written" into cleaner, more natural Chinese, while preserving facts and the original intent.
 
-The canonical documentation is the [Simplified Chinese README](./README.md). This file is only a compact orientation for English readers.
+The canonical documentation is the [Simplified Chinese README](../README.md). This file is only a compact orientation for English readers.
+
+https://github.com/user-attachments/assets/24513c20-968d-437b-8ceb-1ac1f77f6ad6
 
 ## What It Is For
 
@@ -59,12 +61,12 @@ For non-Chinese-speaking users, the safest path is to call the skill explicitly 
 [paste Simplified Chinese text here]
 ```
 
-You can also paste the body of [SKILL.md](./SKILL.md) into an AI model's custom instructions or system prompt. Skip the YAML frontmatter at the top.
+You can also paste the body of [SKILL.md](../SKILL.md) into an AI model's custom instructions or system prompt. Skip the YAML frontmatter at the top.
 
 ## More
 
-- Full docs: [README.md](./README.md)
-- Skill rules: [SKILL.md](./SKILL.md)
-- Supporting references: [references/](./references/)
-- Changes: [CHANGELOG.md](./CHANGELOG.md)
-- License: [MIT](./LICENSE)
+- Full docs: [README.md](../README.md)
+- Skill rules: [SKILL.md](../SKILL.md)
+- Supporting references: [references/](../references/)
+- Changes: [CHANGELOG.md](../CHANGELOG.md)
+- License: [MIT](../LICENSE)

--- a/readmes/README.es.md
+++ b/readmes/README.es.md
@@ -1,10 +1,12 @@
 # qu-ai-wei
 
-[简体中文](./README.md) | [English](./README.en.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | Español
+[简体中文](../README.md) | [English](./README.en.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | Español
 
 qu-ai-wei es un agent skill para reducir el tono de texto generado por IA en **chino simplificado**. Ayuda a convertir un borrador en chino simplificado que suena claramente a IA en un texto más limpio y natural, sin cambiar los hechos ni la intención original.
 
-La documentación canónica es el [README en chino simplificado](./README.md). Este archivo es solo una orientación breve para lectores en español.
+La documentación canónica es el [README en chino simplificado](../README.md). Este archivo es solo una orientación breve para lectores en español.
+
+https://github.com/user-attachments/assets/24513c20-968d-437b-8ceb-1ac1f77f6ad6
 
 ## Para Qué Sirve
 
@@ -59,12 +61,12 @@ Para usuarios que no hablan chino, la opción más segura es llamar el skill de 
 [pega aquí texto en chino simplificado]
 ```
 
-También puedes pegar el cuerpo de [SKILL.md](./SKILL.md) en las instrucciones personalizadas o el system prompt de un modelo de IA. Omite el YAML frontmatter del principio.
+También puedes pegar el cuerpo de [SKILL.md](../SKILL.md) en las instrucciones personalizadas o el system prompt de un modelo de IA. Omite el YAML frontmatter del principio.
 
 ## Más Información
 
-- Documentación completa: [README.md](./README.md)
-- Reglas del skill: [SKILL.md](./SKILL.md)
-- Referencias: [references/](./references/)
-- Cambios: [CHANGELOG.md](./CHANGELOG.md)
-- Licencia: [MIT](./LICENSE)
+- Documentación completa: [README.md](../README.md)
+- Reglas del skill: [SKILL.md](../SKILL.md)
+- Referencias: [references/](../references/)
+- Cambios: [CHANGELOG.md](../CHANGELOG.md)
+- Licencia: [MIT](../LICENSE)

--- a/readmes/README.ja.md
+++ b/readmes/README.ja.md
@@ -1,10 +1,12 @@
 # qu-ai-wei
 
-[简体中文](./README.md) | [English](./README.en.md) | 日本語 | [한국어](./README.ko.md) | [Español](./README.es.md)
+[简体中文](../README.md) | [English](./README.en.md) | 日本語 | [한국어](./README.ko.md) | [Español](./README.es.md)
 
 qu-ai-wei は、**簡体字中国語**の文章から AI っぽさを減らすための agent skill です。簡体字中国語の下書きを、事実と意図を保ったまま、より自然で人が書いたように読める文章へ整えます。
 
-正式なドキュメントは [簡体字中国語 README](./README.md) です。このファイルは、日本語話者向けの短い案内です。
+正式なドキュメントは [簡体字中国語 README](../README.md) です。このファイルは、日本語話者向けの短い案内です。
+
+https://github.com/user-attachments/assets/24513c20-968d-437b-8ceb-1ac1f77f6ad6
 
 ## 何のためのものか
 
@@ -59,12 +61,12 @@ bash scripts/install-skill.sh --platform all
 [ここに簡体字中国語の文章を貼り付ける]
 ```
 
-[SKILL.md](./SKILL.md) の本文を、AI モデルのカスタム指示やシステムプロンプトに貼り付けることもできます。先頭の YAML frontmatter は除いてください。
+[SKILL.md](../SKILL.md) の本文を、AI モデルのカスタム指示やシステムプロンプトに貼り付けることもできます。先頭の YAML frontmatter は除いてください。
 
 ## 関連リンク
 
-- 詳細ドキュメント: [README.md](./README.md)
-- Skill ルール: [SKILL.md](./SKILL.md)
-- 参考資料: [references/](./references/)
-- 変更履歴: [CHANGELOG.md](./CHANGELOG.md)
-- ライセンス: [MIT](./LICENSE)
+- 詳細ドキュメント: [README.md](../README.md)
+- Skill ルール: [SKILL.md](../SKILL.md)
+- 参考資料: [references/](../references/)
+- 変更履歴: [CHANGELOG.md](../CHANGELOG.md)
+- ライセンス: [MIT](../LICENSE)

--- a/readmes/README.ko.md
+++ b/readmes/README.ko.md
@@ -1,10 +1,12 @@
 # qu-ai-wei
 
-[简体中文](./README.md) | [English](./README.en.md) | [日本語](./README.ja.md) | 한국어 | [Español](./README.es.md)
+[简体中文](../README.md) | [English](./README.en.md) | [日本語](./README.ja.md) | 한국어 | [Español](./README.es.md)
 
 qu-ai-wei는 **간체 중국어** 글에서 AI가 쓴 듯한 흔적을 줄이기 위한 agent skill입니다. 간체 중국어 초안의 사실과 의도를 유지하면서 더 자연스럽고 사람이 쓴 듯한 중국어로 다듬는 데 쓰입니다.
 
-정식 문서는 [간체 중국어 README](./README.md)입니다. 이 파일은 한국어 사용자를 위한 짧은 안내입니다.
+정식 문서는 [간체 중국어 README](../README.md)입니다. 이 파일은 한국어 사용자를 위한 짧은 안내입니다.
+
+https://github.com/user-attachments/assets/24513c20-968d-437b-8ceb-1ac1f77f6ad6
 
 ## 무엇을 위한 도구인가
 
@@ -59,12 +61,12 @@ bash scripts/install-skill.sh --platform all
 [여기에 간체 중국어 텍스트를 붙여넣기]
 ```
 
-[SKILL.md](./SKILL.md)의 본문을 AI 모델의 custom instructions 또는 system prompt에 붙여넣어 사용할 수도 있습니다. 맨 위의 YAML frontmatter는 제외하세요.
+[SKILL.md](../SKILL.md)의 본문을 AI 모델의 custom instructions 또는 system prompt에 붙여넣어 사용할 수도 있습니다. 맨 위의 YAML frontmatter는 제외하세요.
 
 ## 더 보기
 
-- 전체 문서: [README.md](./README.md)
-- Skill 규칙: [SKILL.md](./SKILL.md)
-- 참고 자료: [references/](./references/)
-- 변경 내역: [CHANGELOG.md](./CHANGELOG.md)
-- 라이선스: [MIT](./LICENSE)
+- 전체 문서: [README.md](../README.md)
+- Skill 규칙: [SKILL.md](../SKILL.md)
+- 참고 자료: [references/](../references/)
+- 변경 내역: [CHANGELOG.md](../CHANGELOG.md)
+- 라이선스: [MIT](../LICENSE)


### PR DESCRIPTION
## Summary
- Move translated README files into `readmes/` so only the canonical Simplified Chinese README stays at the repo root.
- Update language switcher and moved README links for the new folder depth.
- Embed the existing GitHub-hosted demo video in each translated README.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `bash tests/check-version-sync.sh`
- `bash tests/check-snapshot-smoke.sh`
- local Markdown link check

## Reviewer Verdicts
- CEO / holistic reviewer: SIGN OFF - Docs structure is clear: translated READMEs now live under `readmes/`, root `README.md` links to them, all five READMEs include the existing GitHub-hosted demo video, the Simplified-Chinese-only boundary remains visible, and no `SKILL.md`/`references/`/`.cursorrules`/`WARP.md` changes are present.
- 日常中文表达 expert: SIGN OFF - `README.md` language switching is clear, translated READMEs moved into `readmes/` with correct root links, each README has the video link, Chinese wording is not redundant or translation-stiff, and all translated guides preserve the Simplified-Chinese-only boundary.
- Engineering reviewer: SIGN OFF - Translated README files are moved under `readmes/` with none left at root, root/translated language links and repository links are correct, the GitHub video URL is present in every README, install commands remain accurate, scope is docs-only with no `SKILL.md`/`references/`/`.cursorrules`/`WARP.md` changes, and no flat-build sync is needed.
