### PR TITLE
[codex] Make skills CLI the default install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,34 @@ https://github.com/user-attachments/assets/24513c20-968d-437b-8ceb-1ac1f77f6ad6
 | Slate | `--platform slate` | `~/.slate/skills/qu-ai-wei` |
 | Hermes | `--platform hermes` | `~/.hermes/skills/qu-ai-wei` |
 
-以上 8 个 agent 安装方式完全一致，统一用一个脚本。
+以上 8 个 agent 都可以用本仓库脚本安装。
 
-### 一键安装（推荐）
+### 通过外部 `skills` CLI 安装（推荐）
+
+如果你已经有 Node/npm，可以用外部 `skills` CLI 直接从 GitHub 安装。默认让 `skills` CLI 自动检测本机可用的 agent；没检测到时，它会提示你选择安装目标。
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei
+```
+
+这不是 qu-ai-wei 自己发布 npm 包；命令由 `skills` CLI 拉取本 GitHub 仓库并安装。
+
+如果想明确安装到某个 agent，用 `-a` 指定：
+
+```bash
+# 只装到 Codex
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex
+
+# 同时装到多个 agent
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex -a claude-code -a cursor
+
+# 装到全局目录，并跳过确认提示
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -g -a codex -y
+```
+
+### 本仓库脚本安装（全控制路径）
+
+如果需要一次装全、软链接 / 复制模式、自定义目录或可重复覆盖，继续用本仓库脚本：
 
 ```bash
 git clone https://github.com/LifelongLazyLearner/qu-ai-wei.git ~/qu-ai-wei

--- a/readmes/README.en.md
+++ b/readmes/README.en.md
@@ -40,6 +40,22 @@ It cannot:
 
 The same install script supports Cursor, Claude Code, OpenAI Codex CLI, OpenCode, Kiro, Factory Droid, Slate, and Hermes.
 
+With Node/npm installed, the recommended path is the external `skills` CLI. By default it detects available agents, or prompts you to choose one:
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei
+```
+
+This uses the external `skills` CLI to fetch this GitHub repository. It is not a qu-ai-wei npm package.
+
+To target specific agents, add `-a`:
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex -a claude-code -a cursor
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -g -a codex -y
+```
+
 ```bash
 git clone https://github.com/LifelongLazyLearner/qu-ai-wei.git ~/qu-ai-wei
 cd ~/qu-ai-wei

--- a/readmes/README.es.md
+++ b/readmes/README.es.md
@@ -40,6 +40,22 @@ No puede:
 
 El mismo script de instalación admite Cursor, Claude Code, OpenAI Codex CLI, OpenCode, Kiro, Factory Droid, Slate y Hermes.
 
+Si tienes Node/npm, la ruta recomendada es el `skills` CLI externo. Por defecto detecta los agents disponibles, o te pide elegir uno si no detecta ninguno:
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei
+```
+
+Este método usa el `skills` CLI externo para traer este repositorio de GitHub. No es un paquete npm de qu-ai-wei.
+
+Para instalarlo en agents concretos, añade `-a`:
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex -a claude-code -a cursor
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -g -a codex -y
+```
+
 ```bash
 git clone https://github.com/LifelongLazyLearner/qu-ai-wei.git ~/qu-ai-wei
 cd ~/qu-ai-wei

--- a/readmes/README.ja.md
+++ b/readmes/README.ja.md
@@ -40,6 +40,22 @@ qu-ai-wei が対応するのは **簡体字中国語だけ**です。
 
 同じインストールスクリプトで、Cursor、Claude Code、OpenAI Codex CLI、OpenCode、Kiro、Factory Droid、Slate、Hermes に対応しています。
 
+Node/npm がある場合は、外部の `skills` CLI で入れる方法がおすすめです。デフォルトでは利用可能な agent を自動検出し、見つからない場合は選択を促します。
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei
+```
+
+これは外部 `skills` CLI が GitHub リポジトリを取得して入れる方法です。qu-ai-wei の npm package ではありません。
+
+特定の agent に入れたい場合は `-a` を付けます。
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex -a claude-code -a cursor
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -g -a codex -y
+```
+
 ```bash
 git clone https://github.com/LifelongLazyLearner/qu-ai-wei.git ~/qu-ai-wei
 cd ~/qu-ai-wei

--- a/readmes/README.ko.md
+++ b/readmes/README.ko.md
@@ -40,6 +40,22 @@ qu-ai-wei는 **간체 중국어만 지원합니다**.
 
 하나의 설치 스크립트로 Cursor, Claude Code, OpenAI Codex CLI, OpenCode, Kiro, Factory Droid, Slate, Hermes를 지원합니다.
 
+Node/npm이 있다면 외부 `skills` CLI 설치를 권장합니다. 기본값은 사용 가능한 agent를 자동 감지하고, 찾지 못하면 설치 대상을 선택하라고 안내합니다.
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei
+```
+
+이 방법은 외부 `skills` CLI가 GitHub 저장소를 가져와 설치합니다. qu-ai-wei npm package가 아닙니다.
+
+특정 agent에 설치하려면 `-a`를 붙입니다.
+
+```bash
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -a codex -a claude-code -a cursor
+npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei -g -a codex -y
+```
+
 ```bash
 git clone https://github.com/LifelongLazyLearner/qu-ai-wei.git ~/qu-ai-wei
 cd ~/qu-ai-wei

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # tests/
 
-回归样本和轻量检查脚本。当前包含 17 条手工回归样本 + 3 个自动化同步检查。
+回归样本和轻量检查脚本。当前包含手工回归样本和 4 个自动化检查。
 
 ## 目录
 
@@ -29,6 +29,7 @@
 
 - **`check-version-sync.sh`** — 自动检查 `README.md` / `CHANGELOG.md` / `SKILL.md` / `.cursorrules` / `WARP.md` 的版本号是否同步。
 - **`check-snapshot-smoke.sh`** — 轻量检查 `tests/after/` 里的快照结构是否完整,并对 v0.6.4 新增的 04 / 05、v0.6.5 新增的 06-12、v0.6.6 新增的 13-17 样本做关键断言。
+- **`check-skills-cli-discovery.sh`** — 用 pinned `skills@1.5.13` 跑 `npx --yes skills@1.5.13 add . --list`,只检查外部 `skills` CLI 能发现 `qu-ai-wei`,不做实际安装。
 - **`eval-manifest.txt` + `check-runs.sh`** — 可复用的真实运行检查器。`tests/after/` 仍是人工 anchor output;未来真实模型输出放到 `tests/runs/<version>-<model>/`,再用同一份 manifest 校验。
 - **`runs/README.md`** — 真实模型输出的手工 capture 规范,包含必填 metadata header。
 
@@ -45,6 +46,9 @@ bash tests/check-version-sync.sh
 
 # 快照 smoke check
 bash tests/check-snapshot-smoke.sh
+
+# 外部 skills CLI 发现检查(不安装)
+bash tests/check-skills-cli-discovery.sh
 
 # manifest-based run check(先验证现有 anchor output;真实运行输出同理)
 bash tests/check-runs.sh tests/after
@@ -68,6 +72,7 @@ bash tests/check-runs.sh tests/after
 # 1) 先跑自动检查
 bash tests/check-version-sync.sh
 bash tests/check-snapshot-smoke.sh
+bash tests/check-skills-cli-discovery.sh
 
 # 2) 手工法:用一个干净会话,让模型读 SKILL.md + 当前 references/,逐个处理 fixtures/
 # 输出到 tests/after/(或新建 tests/after-<versiontag>/),然后 diff 旧 after。

--- a/tests/check-skills-cli-discovery.sh
+++ b/tests/check-skills-cli-discovery.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+OUT="$(mktemp)"
+trap 'rm -f "$OUT"' EXIT
+
+if ! npx --yes skills@1.5.13 add . --list >"$OUT" 2>&1; then
+  cat "$OUT" >&2
+  echo "skills CLI discovery failed" >&2
+  exit 1
+fi
+
+if ! rg -q --fixed-strings "Found 1 skill" "$OUT"; then
+  cat "$OUT" >&2
+  echo "skills CLI did not report exactly one discovered skill" >&2
+  exit 1
+fi
+
+if ! rg -q "qu-ai-wei[[:space:]]*$" "$OUT"; then
+  cat "$OUT" >&2
+  echo "skills CLI did not list qu-ai-wei" >&2
+  exit 1
+fi
+
+echo "skills CLI discovery ok: qu-ai-wei"


### PR DESCRIPTION
## Summary
- Make `npx skills add https://github.com/LifelongLazyLearner/qu-ai-wei` the default install path in the canonical and multilingual READMEs.
- Keep the repo-local install script as the full-control path for custom targets, symlink/copy mode, and force/reinstall flows.
- Add a pinned, non-installing `skills@1.5.13` discovery smoke check and document it in `tests/README.md`.

## Validation
- `bash tests/check-version-sync.sh`
- `bash tests/check-snapshot-smoke.sh`
- `bash tests/check-skills-cli-discovery.sh`
- `git diff --check`

## Review Gate
- CEO / holistic reviewer: sign off
- 日常中文表达 expert (adversarial): sign off
- Engineering reviewer (skill effectiveness): sign off
